### PR TITLE
feat: add repository using DbContextFactory

### DIFF
--- a/DbContextDemo.API/Persistance/IUsesDbContextFactoryRepository.cs
+++ b/DbContextDemo.API/Persistance/IUsesDbContextFactoryRepository.cs
@@ -1,0 +1,13 @@
+using DbContextDemo.API.Persistance.Models.Base;
+
+namespace DbContextDemo.Persistance;
+
+public interface IUsesDbContextFactoryRepository<T> where T : BaseEntity
+{
+    Task<T?> GetByIdAsync(Guid id);
+    Task<IEnumerable<T>> GetByIdsAsync(IEnumerable<Guid> ids);
+    Task<IEnumerable<T>> GetAllAsync();
+    Task AddAsync(T entity);
+    Task UpdateAsync(T entity);
+    Task DeleteAsync(T entity);
+}

--- a/DbContextDemo.API/Persistance/UsesDbContextFactoryRepository.cs
+++ b/DbContextDemo.API/Persistance/UsesDbContextFactoryRepository.cs
@@ -1,0 +1,64 @@
+using DbContextDemo.API.Persistance.Models.Base;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DbContextDemo.Persistance;
+
+public class UsesDbContextFactoryRepository<T> : IUsesDbContextFactoryRepository<T> where T : BaseEntity
+{
+    private readonly IDbContextFactory<AppDbContext> _contextFactory;
+    private readonly ILogger<UsesDbContextFactoryRepository<T>> _logger;
+
+    public UsesDbContextFactoryRepository(IDbContextFactory<AppDbContext> contextFactory, ILogger<UsesDbContextFactoryRepository<T>> logger)
+    {
+        _contextFactory = contextFactory;
+        _logger = logger;
+    }
+
+    // Demo helper: lets you see the instance identity of the context being used
+    private static Guid ContextInstanceId(AppDbContext context) => context.ContextId.InstanceId;
+
+    public async Task<T?> GetByIdAsync(Guid id)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        return await context.Set<T>().FindAsync(id);
+    }
+
+    public async Task<IEnumerable<T>> GetByIdsAsync(IEnumerable<Guid> ids)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        return await context.Set<T>().Where(e => ids.Contains(e.Id)).ToListAsync();
+    }
+
+    public async Task<IEnumerable<T>> GetAllAsync()
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        return await context.Set<T>().ToListAsync();
+    }
+
+    public async Task AddAsync(T entity)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        await context.Set<T>().AddAsync(entity);
+        _logger.LogInformation("Saving changes in AppDbContext: {id}", ContextInstanceId(context));
+        await context.SaveChangesAsync();
+    }
+
+    public async Task UpdateAsync(T entity)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        context.Set<T>().Update(entity);
+        _logger.LogInformation("Saving changes in AppDbContext: {id}", ContextInstanceId(context));
+        await context.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(T entity)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        context.Set<T>().Remove(entity);
+        _logger.LogInformation("Saving changes in AppDbContext: {id}", ContextInstanceId(context));
+        await context.SaveChangesAsync();
+    }
+
+}
+

--- a/DbContextDemo.API/Program.cs
+++ b/DbContextDemo.API/Program.cs
@@ -15,10 +15,13 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+builder.Services.AddDbContextFactory<AppDbContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 
 // Generic repo resolves to your concrete repo
 builder.Services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
+builder.Services.AddScoped(typeof(IUsesDbContextFactoryRepository<>), typeof(UsesDbContextFactoryRepository<>));
 
 builder.Services.AddScoped<IOrderService, OrderService>();
 


### PR DESCRIPTION
## Summary
- add UsesDbContextFactoryRepository creating a new DbContext per method
- register DbContextFactory in Program.cs
- refactor repository to expose context instance id via helper for logging
- introduce IUsesDbContextFactoryRepository without SaveChanges and register it for side-by-side comparison
- update factory repository interface so Update/Delete are async and remove internal wrappers

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.35 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68b14e6fcaa8832caa9b51c83245772e