### PR TITLE
Ensure repository gets fresh DbContext per call

### DIFF
--- a/DbContextDemo.API/Persistance/Repositories/Implementations/UsesDbContextFactoryRepository.cs
+++ b/DbContextDemo.API/Persistance/Repositories/Implementations/UsesDbContextFactoryRepository.cs
@@ -17,43 +17,66 @@ public class UsesDbContextFactoryRepository<T> : IUsesDbContextFactoryRepository
         _logger = logger;
     }
 
+    public Task<AppDbContext> GetDbContextAsync()
+    {
+        return _contextFactory.CreateDbContextAsync();
+    }
+
     public async Task<T?> GetByIdAsync(Guid id)
     {
-        await using var context = await _contextFactory.CreateDbContextAsync();
-        return await context.Set<T>().FindAsync(id);
+        await using var dbContext = await _contextFactory.CreateDbContextAsync();
+        return await dbContext.Set<T>().FindAsync(id);
     }
 
     public async Task<IEnumerable<T>> GetByIdsAsync(IEnumerable<Guid> ids)
     {
-        await using var context = await _contextFactory.CreateDbContextAsync();
-        return await context.Set<T>().Where(e => ids.Contains(e.Id)).ToListAsync();
+        await using var dbContext = await _contextFactory.CreateDbContextAsync();
+        return await dbContext.Set<T>().Where(e => ids.Contains(e.Id)).ToListAsync();
     }
 
     public async Task<IEnumerable<T>> GetAllAsync()
     {
-        await using var context = await _contextFactory.CreateDbContextAsync();
-        return await context.Set<T>().ToListAsync();
+        await using var dbContext = await _contextFactory.CreateDbContextAsync();
+        return await dbContext.Set<T>().ToListAsync();
     }
 
     public async Task AddAsync(T entity)
     {
-        await using var context = await _contextFactory.CreateDbContextAsync();
-        await context.Set<T>().AddAsync(entity);
-        await context.SaveChangesAsync();
+        await using var dbContext = await _contextFactory.CreateDbContextAsync();
+        await dbContext.Set<T>().AddAsync(entity);
+        await dbContext.SaveChangesAsync();
+    }
+
+    public async Task AddAsync(T entity, AppDbContext dbContext)
+    {
+        await dbContext.Set<T>().AddAsync(entity);
+        await dbContext.SaveChangesAsync();
     }
 
     public async Task UpdateAsync(T entity)
     {
-        await using var context = await _contextFactory.CreateDbContextAsync();
-        context.Set<T>().Update(entity);
-        await context.SaveChangesAsync();
+        await using var dbContext = await _contextFactory.CreateDbContextAsync();
+        dbContext.Set<T>().Update(entity);
+        await dbContext.SaveChangesAsync();
+    }
+
+    public async Task UpdateAsync(T entity, AppDbContext dbContext)
+    {
+        dbContext.Set<T>().Update(entity);
+        await dbContext.SaveChangesAsync();
     }
 
     public async Task DeleteAsync(T entity)
     {
-        await using var context = await _contextFactory.CreateDbContextAsync();
-        context.Set<T>().Remove(entity);
-        await context.SaveChangesAsync();
+        await using var dbContext = await _contextFactory.CreateDbContextAsync();
+        dbContext.Set<T>().Remove(entity);
+        await dbContext.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(T entity, AppDbContext dbContext)
+    {
+        dbContext.Set<T>().Remove(entity);
+        await dbContext.SaveChangesAsync();
     }
 
 

--- a/DbContextDemo.API/Persistance/Repositories/Interfaces/IUsesDbContextFactoryRepository.cs
+++ b/DbContextDemo.API/Persistance/Repositories/Interfaces/IUsesDbContextFactoryRepository.cs
@@ -1,13 +1,18 @@
 using DbContextDemo.API.Persistance.Models.Base;
+using DbContextDemo.Persistance;
 
 namespace DbContextDemo.API.Persistance.Repositories.Implementations;
 
 public interface IUsesDbContextFactoryRepository<T> where T : BaseEntity
 {
+    Task<AppDbContext> GetDbContextAsync();
     Task<T?> GetByIdAsync(Guid id);
     Task<IEnumerable<T>> GetByIdsAsync(IEnumerable<Guid> ids);
     Task<IEnumerable<T>> GetAllAsync();
     Task AddAsync(T entity);
+    Task AddAsync(T entity, AppDbContext dbContext);
     Task UpdateAsync(T entity);
+    Task UpdateAsync(T entity, AppDbContext dbContext);
     Task DeleteAsync(T entity);
+    Task DeleteAsync(T entity, AppDbContext dbContext);
 }


### PR DESCRIPTION
## Summary
- expose `GetDbContextAsync` to retrieve a new context from the factory
- use `await using` to create a fresh context for each CRUD method
- add overloads for Create/Update/Delete accepting an existing `AppDbContext`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b243d47798832c802e0e9f54e7a632