### PR TITLE
Add transaction-based OrderServiceB with ConfigureAwait usage

### DIFF
--- a/DbContextDemo.API/Infrastructure/Repositories/Implementations/UsesAmbientDbContextRepository.cs
+++ b/DbContextDemo.API/Infrastructure/Repositories/Implementations/UsesAmbientDbContextRepository.cs
@@ -82,7 +82,7 @@ namespace DbContextDemo.API.Infrastructure.Repositories.Implementations
         // Temporal reads
         public virtual Task<TType?> GetRecordHistoryAsOfDateAsync(Guid Id, DateTime dateTime, CancellationToken ct = default)
             => ExecuteReadAsync(async db =>
-                await db.Set<Type>().FindAsync(Id) as TType, ct); // Placeholder; user may replace with their temporal logic
+                await db.Set<Type>().FindAsync(Id).ConfigureAwait(false) as TType, ct); // Placeholder; user may replace with their temporal logic
 
         public virtual Task<TType?> GetRecordBetweenDatesAsync(Guid Id, DateTime start, DateTime end, CancellationToken ct = default)
             => ExecuteReadAsync(async db => await db.Set<TType>().TemporalBetween(start, end).IgnoreAutoIncludes().FirstOrDefaultAsync(x => x.Id == Id, ct).ConfigureAwait(false), ct);

--- a/DbContextDemo.API/Infrastructure/Repositories/Implementations/UsesDbContextFactoryRepository.cs
+++ b/DbContextDemo.API/Infrastructure/Repositories/Implementations/UsesDbContextFactoryRepository.cs
@@ -17,66 +17,66 @@ public class UsesDbContextFactoryRepository<T> : IUsesDbContextFactoryRepository
         _logger = logger;
     }
 
-    public Task<AppDbContext> GetDbContextAsync()
+    public async Task<AppDbContext> GetDbContextAsync()
     {
-        return _contextFactory.CreateDbContextAsync();
+        return await _contextFactory.CreateDbContextAsync().ConfigureAwait(false);
     }
 
     public async Task<T?> GetByIdAsync(Guid id)
     {
-        await using var dbContext = await _contextFactory.CreateDbContextAsync();
-        return await dbContext.Set<T>().FindAsync(id);
+        await using var dbContext = await _contextFactory.CreateDbContextAsync().ConfigureAwait(false);
+        return await dbContext.Set<T>().FindAsync(id).ConfigureAwait(false);
     }
 
     public async Task<IEnumerable<T>> GetByIdsAsync(IEnumerable<Guid> ids)
     {
-        await using var dbContext = await _contextFactory.CreateDbContextAsync();
-        return await dbContext.Set<T>().Where(e => ids.Contains(e.Id)).ToListAsync();
+        await using var dbContext = await _contextFactory.CreateDbContextAsync().ConfigureAwait(false);
+        return await dbContext.Set<T>().Where(e => ids.Contains(e.Id)).ToListAsync().ConfigureAwait(false);
     }
 
     public async Task<IEnumerable<T>> GetAllAsync()
     {
-        await using var dbContext = await _contextFactory.CreateDbContextAsync();
-        return await dbContext.Set<T>().ToListAsync();
+        await using var dbContext = await _contextFactory.CreateDbContextAsync().ConfigureAwait(false);
+        return await dbContext.Set<T>().ToListAsync().ConfigureAwait(false);
     }
 
     public async Task AddAsync(T entity)
     {
-        await using var dbContext = await _contextFactory.CreateDbContextAsync();
-        await dbContext.Set<T>().AddAsync(entity);
-        await dbContext.SaveChangesAsync();
+        await using var dbContext = await _contextFactory.CreateDbContextAsync().ConfigureAwait(false);
+        await dbContext.Set<T>().AddAsync(entity).ConfigureAwait(false);
+        await dbContext.SaveChangesAsync().ConfigureAwait(false);
     }
 
     public async Task AddAsync(T entity, AppDbContext dbContext)
     {
-        await dbContext.Set<T>().AddAsync(entity);
-        await dbContext.SaveChangesAsync();
+        await dbContext.Set<T>().AddAsync(entity).ConfigureAwait(false);
+        await dbContext.SaveChangesAsync().ConfigureAwait(false);
     }
 
     public async Task UpdateAsync(T entity)
     {
-        await using var dbContext = await _contextFactory.CreateDbContextAsync();
+        await using var dbContext = await _contextFactory.CreateDbContextAsync().ConfigureAwait(false);
         dbContext.Set<T>().Update(entity);
-        await dbContext.SaveChangesAsync();
+        await dbContext.SaveChangesAsync().ConfigureAwait(false);
     }
 
     public async Task UpdateAsync(T entity, AppDbContext dbContext)
     {
         dbContext.Set<T>().Update(entity);
-        await dbContext.SaveChangesAsync();
+        await dbContext.SaveChangesAsync().ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(T entity)
     {
-        await using var dbContext = await _contextFactory.CreateDbContextAsync();
+        await using var dbContext = await _contextFactory.CreateDbContextAsync().ConfigureAwait(false);
         dbContext.Set<T>().Remove(entity);
-        await dbContext.SaveChangesAsync();
+        await dbContext.SaveChangesAsync().ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(T entity, AppDbContext dbContext)
     {
         dbContext.Set<T>().Remove(entity);
-        await dbContext.SaveChangesAsync();
+        await dbContext.SaveChangesAsync().ConfigureAwait(false);
     }
 
 


### PR DESCRIPTION
## Summary
- rename previous ambient-context-based OrderServiceB to OrderServiceC
- add new OrderServiceB using UsesDbContextFactoryRepository with explicit transactions
- ensure OrderServiceB and related repositories use ConfigureAwait(false)

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c9be62b0832cb2a539fb10c95c9f